### PR TITLE
style: update paper-card padding to improve readability

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -409,7 +409,7 @@ toggleMoreInfo(action, domain = null, entities = null, entityName = null) {
 
       static get styles() {
         return css`
-            paper-tabs { height: 110px; }
+            paper-tabs { height: 110px; padding: 4px 8px }
             paper-tab {padding: 0 5px; }
             .entity, .extra-entity { display: flex; flex-direction: column; align-items: center;}
             .entity-icon { width: 50px; height: 50px; border-radius: 50%;


### PR DESCRIPTION
Hi @xBourner !
First of all, I wanna say a huge thanks for your work! It's really good, and even though I just discovered it yesterday and installed it today, I already love it! 

I'm opening this PR because there's a tiny detail that bugs me, and could not get my brain out of it: the padding of the component. I played in the dev tools and I find that a padding of `4px 8xp` helps with the general readability, and improves the global layout.

Here's some before/after screenshots: 

**before**
<img width="226" alt="Capture d’écran 2024-11-14 à 21 15 22" src="https://github.com/user-attachments/assets/9298d875-3635-4d97-9a2a-bc318339ffaf">

**after**
<img width="284" alt="Capture d’écran 2024-11-14 à 21 15 55" src="https://github.com/user-attachments/assets/d341d870-b9f4-420c-bbd3-fc672aca4007">


There's maybe some considerations I don't have in mind (smaller screens, phones, lot of displayed entities etc.), but I give it a try. 

Cheers :) 

