### PR TITLE
style: update Dialog layout to avoid misalignment 

### DIFF
--- a/src/card.js
+++ b/src/card.js
@@ -420,12 +420,12 @@ toggleMoreInfo(action, domain = null, entities = null, entityName = null) {
             .entity-info { text-align: center; margin-top: 5px; }
             .entity-name { font-weight: bold; margin-bottom: 2px; }
             .entity-state { color: var(--secondary-text-color); font-size: 0.9em; }
-            .dialog-header { display: flex; align-items: center; justify-content: space-between; flex-direction: row-reverse; gap: 8px; margin-bottom: 1.5vh}  
+            .dialog-header { display: flex; align-items: center; justify-content: flex-start; gap: 8px; margin-bottom: 8px}  
             .dialog-header ha-icon-button { margin-right: 10px; }
             .dialog-header h3 { margin: 0 }
             ha-dialog#more-info-dialog { --mdc-dialog-max-width: 90vw; } 
-            .tile-container { display: flex; flex-wrap: wrap; gap: 4px; padding: 10px; }
-            .tile-container .dialog-icon-button-header { margin: 0; border-radius:100vh; background-color: rgba(0,0,0,0.3); }
+            .tile-container { display: flex; flex-wrap: wrap; gap: 4px; padding: 0 }
+            .tile-container .dialog-icon-button-header { margin: 0; }
             .entity-card { width: 21vw; box-sizing: border-box; }
             .entity-list { list-style: none; }
             @media (max-width: 768px) {

--- a/src/card.js
+++ b/src/card.js
@@ -370,7 +370,7 @@ toggleMoreInfo(action, domain = null, entities = null, entityName = null) {
     return html`
       <ha-dialog id="more-info-dialog" style="display:none;">
         <div class="dialog-header">
-          <ha-icon-button slot="navigationIcon" dialogaction="cancel" @click=${() => this.toggleMoreInfo('close')} title="Schließen">
+          <ha-icon-button class="dialog-icon-button-header" slot="navigationIcon" dialogaction="cancel" @click=${() => this.toggleMoreInfo('close')} title="Schließen">
             <ha-icon icon="mdi:close"></ha-icon>
           </ha-icon-button>
           <h3>${this.hass.localize("ui.panel.lovelace.editor.card.entities.name")} in ${this.selectedEntityName}:</h3>
@@ -420,11 +420,12 @@ toggleMoreInfo(action, domain = null, entities = null, entityName = null) {
             .entity-info { text-align: center; margin-top: 5px; }
             .entity-name { font-weight: bold; margin-bottom: 2px; }
             .entity-state { color: var(--secondary-text-color); font-size: 0.9em; }
-            .dialog-header { display: flex; align-items: center; justify-content: flex-start;}  
+            .dialog-header { display: flex; align-items: center; justify-content: space-between; flex-direction: row-reverse; gap: 8px; margin-bottom: 1.5vh}  
             .dialog-header ha-icon-button { margin-right: 10px; }
-            .dialog-header h3 { margin-bottom: 10px; }
+            .dialog-header h3 { margin: 0 }
             ha-dialog#more-info-dialog { --mdc-dialog-max-width: 90vw; } 
             .tile-container { display: flex; flex-wrap: wrap; gap: 4px; padding: 10px; }
+            .tile-container .dialog-icon-button-header { margin: 0; border-radius:100vh; background-color: rgba(0,0,0,0.3); }
             .entity-card { width: 21vw; box-sizing: border-box; }
             .entity-list { list-style: none; }
             @media (max-width: 768px) {


### PR DESCRIPTION
This PR aims to improve the Dialog layout to avoid misalignment of content. 

- The "x" of the Icon button is not centered in the button
- the padding of the `tile-container` was misaligning the content and the header. 

See screenshots below for the before and after: 

**Before**
<img width="284" alt="Capture d’écran 2024-11-17 à 18 26 13" src="https://github.com/user-attachments/assets/56fef101-a58a-4aeb-85e5-54e6897a4512">

**After**
<img width="255" alt="Capture d’écran 2024-11-17 à 18 26 25" src="https://github.com/user-attachments/assets/dc8c776a-42f0-4517-a430-1cf56a21d927">

