### PR TITLE
feat: add hidden_persons to filter individual persons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "status-card",
-  "version": "v3.1.1",
+  "version": "v3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "status-card",
-      "version": "v3.1.1",
+      "version": "v3.2.1",
       "dependencies": {
         "@mdi/js": "^7.4.47",
         "custom-card-helpers": "^1.9.0",
@@ -1093,6 +1093,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/src/card-items.ts
+++ b/src/card-items.ts
@@ -20,6 +20,7 @@ export const getPersonEntityIds = (
   entities: HomeAssistant["entities"],
   hiddenEntities: string[],
   hiddenLabels: string[],
+  hiddenPersons: string[],
   hide_person: boolean
 ): string[] => {
   if (hide_person) return [];
@@ -28,6 +29,7 @@ export const getPersonEntityIds = (
       (entity) =>
         entity.entity_id.startsWith("person.") &&
         !hiddenEntities.includes(entity.entity_id) &&
+        !hiddenPersons.includes(entity.entity_id) &&
         !entity.labels?.some((l) => hiddenLabels.includes(l)) &&
         !entity.hidden
     )
@@ -48,6 +50,7 @@ export const computePersonItems = (
   entities: HomeAssistant["entities"],
   hiddenEntities: string[],
   hiddenLabels: string[],
+  hiddenPersons: string[],
   hide_person: boolean,
   hassStates: HomeAssistant["states"]
 ): HassEntity[] => {
@@ -55,6 +58,7 @@ export const computePersonItems = (
     entities,
     hiddenEntities,
     hiddenLabels,
+    hiddenPersons,
     hide_person
   );
   return mapPersonIdsToStates(ids, hassStates);

--- a/src/card.ts
+++ b/src/card.ts
@@ -77,6 +77,7 @@ export class StatusCard extends LitElement {
   @state() public hiddenEntities: string[] = [];
   @state() private hiddenLabels: string[] = [];
   @state() private hiddenAreas: string[] = [];
+  @state() private hiddenPersons: string[] = [];
   @state() private hide_person: boolean = false;
   @state() private hide_content_name: boolean = true;
   @state() public list_mode: boolean = false;
@@ -461,6 +462,7 @@ export class StatusCard extends LitElement {
     this.hiddenEntities = config.hidden_entities || [];
     this.hiddenLabels = config.hidden_labels || [];
     this.hiddenAreas = config.hidden_areas || [];
+    this.hiddenPersons = config.hidden_persons || [];
 
     if (this._config.customization) {
     }
@@ -726,6 +728,7 @@ export class StatusCard extends LitElement {
       this.hass.entities,
       this.hiddenEntities,
       this.hiddenLabels,
+      this.hiddenPersons,
       this.hide_person
     );
     return this._mapPersonIdsToStatesMemo(ids, this.hass.states);

--- a/src/editor-schema.ts
+++ b/src/editor-schema.ts
@@ -21,36 +21,6 @@ export function getConfigSchema(
 
   return [
     {
-      name: "person",
-      // @ts-ignore
-      flatten: true,
-      type: "expandable",
-      icon: "mdi:account",
-      schema: [
-        { name: "hide_person", selector: { boolean: {} } },
-        {
-          name: "person_home_color",
-          selector: {
-            ui_color: { default_color: "state", include_state: true },
-          },
-        },
-        {
-          name: "person_away_color",
-          selector: {
-            ui_color: { default_color: "state", include_state: true },
-          },
-        },
-        {
-          name: "person_home_icon",
-          selector: { icon: { placeholder: "mdi:home" } },
-        },
-        {
-          name: "person_away_icon",
-          selector: { icon: { placeholder: "mdi:home-export-outline" } },
-        },
-      ],
-    },
-    {
       name: "edit_filters",
       // @ts-ignore
       flatten: true,


### PR DESCRIPTION
add ability to hide specific person entities from the status card.
=> This allows users to filter out individual persons without hiding all person entities completely via hide_person. (me for example have 2 "worker" users for my Display and MQTT)

Before:
<img width="537" height="178" alt="image" src="https://github.com/user-attachments/assets/b22076dc-e56e-4d5f-a71a-817c5034a2ac" />

Editor:
<img width="420" height="599" alt="image" src="https://github.com/user-attachments/assets/0a672ce7-0a5f-47dc-a7cb-10d8fe6cd8d5" />

After: 
<img width="428" height="148" alt="image" src="https://github.com/user-attachments/assets/f4327251-7cb1-47c4-a700-f59b2609d6c0" />
