### PR TITLE
fix: respect smart group filters when hiding empty card

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -659,23 +659,33 @@ export class StatusCard extends LitElement {
       return true;
     }
 
-    const candidatesMap = this._computeGroupCandidatesMemo(
-      this._config.rulesets || [],
-      this.__registryEntities,
-      this.__registryDevices,
-      this.__registryAreas,
-      this.hiddenEntities,
-    );
+    const groupItems = this.getGroupItems();
 
-    const hasGroupContent = this.getGroupItems().some((g) => {
-      const candidates = candidatesMap.get(g.group_id) || [];
-      if (candidates.length === 0) return false;
-      return candidates.some(
-        (eid) => this.hass.states[eid] && !STATES_OFF.includes(this.hass.states[eid].state)
+    if (groupItems.length > 0) {
+      const candidatesMap = this._computeGroupCandidatesMemo(
+          this._config.rulesets || [],
+          this.__registryEntities,
+          this.__registryDevices,
+          this.__registryAreas,
+          this.hiddenEntities,
       );
-    });
-    if (hasGroupContent) {
-      return true;
+
+      const groupResults = this._computeGroupResultsMemo(
+          candidatesMap,
+          this.hass.states,
+          this._config.rulesets || [],
+          this.__registryEntities,
+          this.__registryDevices,
+          this.__registryAreas,
+      );
+
+      const hasGroupContent = groupItems.some(
+          (group) => (groupResults.get(group.group_id) || []).length > 0,
+      );
+
+      if (hasGroupContent) {
+        return true;
+      }
     }
 
     const includedIds = this._computeIncludedIdsMemo(


### PR DESCRIPTION
Use fully filtered smart group results when evaluating hide_card_if_empty.

This prevents the card from staying visible when a smart group has static candidates but no entities matching its dynamic filters.